### PR TITLE
fix: sse should ignore comment 

### DIFF
--- a/llms/ernie/internal/ernieclient/chat.go
+++ b/llms/ernie/internal/ernieclient/chat.go
@@ -197,7 +197,9 @@ func parseStreamingChatResponse(ctx context.Context, r *http.Response, payload *
 		defer close(responseChan)
 		for scanner.Scan() {
 			line := scanner.Text()
-			if line == "" {
+			// A colon as the first character of a line is in essence a comment, and is ignored.
+			// ref: https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#event_stream_format
+			if line == "" || strings.HasPrefix(line, ":") {
 				continue
 			}
 			if !strings.HasPrefix(line, "data:") {

--- a/llms/openai/internal/openaiclient/chat.go
+++ b/llms/openai/internal/openaiclient/chat.go
@@ -235,7 +235,9 @@ func parseStreamingChatResponse(ctx context.Context, r *http.Response, payload *
 		defer close(responseChan)
 		for scanner.Scan() {
 			line := scanner.Text()
-			if line == "" {
+			// A colon as the first character of a line is in essence a comment, and is ignored.
+			// ref: https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#event_stream_format
+			if line == "" || strings.HasPrefix(line, ":") {
 				continue
 			}
 			if !strings.HasPrefix(line, "data:") {


### PR DESCRIPTION
> A colon as the first character of a line is in essence a comment, and is ignored.

ref: https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#event_stream_format

I haven't seen openai officially use colons in SSE, but I have seen openai-like services use colons to prevent connections from being disconnected, for example: `: ping - 2024-02-23 06:52:12.876102` by LLaMA-Factory